### PR TITLE
feature/page-layout

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import requireContext from 'require-context.macro';
 import { checkA11y } from '@storybook/addon-a11y';
 import { configureActions } from '@storybook/addon-actions';
@@ -112,6 +113,9 @@ addDecorator(checkA11y);
 configureViewport({
   defaultViewport: 'responsive'
 });
+
+// Wrap each story within Router component
+addDecorator(story => <Router>{story()}</Router>);
 
 // Wrap each story within a container
 addDecorator(story => <Wrapper>{story()}</Wrapper>);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import requireContext from 'require-context.macro';
+import { ThemeProvider as Theme } from 'styled-components';
 import { checkA11y } from '@storybook/addon-a11y';
 import { configureActions } from '@storybook/addon-actions';
 import { withBackgrounds } from '@storybook/addon-backgrounds';
@@ -13,6 +14,9 @@ import { addDecorator, configure } from '@storybook/react';
 
 // Application styles
 import '../src/styles/index.scss';
+
+// Theme
+import theme from '../src/config/theme';
 
 // Decorators
 import Wrapper from './decorators/Wrapper';
@@ -116,6 +120,9 @@ configureViewport({
 
 // Wrap each story within Router component
 addDecorator(story => <Router>{story()}</Router>);
+
+// Wrap each story within Styled Component theme
+addDecorator(story => <Theme theme={theme}>{story()}</Theme>);
 
 // Wrap each story within a container
 addDecorator(story => <Wrapper>{story()}</Wrapper>);

--- a/.stylelintrc.styled.json
+++ b/.stylelintrc.styled.json
@@ -4,5 +4,22 @@
     "stylelint-config-styled-components",
     "stylelint-config-prettier"
   ],
-  "processors": ["stylelint-processor-styled-components"]
+  "processors": ["stylelint-processor-styled-components"],
+  "rules": {
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": [
+          "each",
+          "extend",
+          "function",
+          "if",
+          "include",
+          "mixin"
+        ]
+      }
+    ],
+    "no-descending-specificity": null,
+    "no-empty-source": null
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,8 @@
     ".prettierrc": "json",
     ".stylelintrc": "json",
     ".stylelintrc.styled.json": "json",
-    "*.test.js.snap": "javascript"
+    "*.test.js.snap": "javascript",
+    "*.test.jsx.snap": "javascript"
   },
 
   // Prettier

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div class="root" id="root"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/components/common/base/Grid/Column/Column.stories.jsx
+++ b/src/components/common/base/Grid/Column/Column.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
+import Column from './index';
+
+const { content } = mock.elements;
+const title = 'Components/Common/Base/Grid/Column';
+const component = <Column>{content}</Column>;
+
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.minimal
+});

--- a/src/components/common/base/Grid/Column/__tests__/Column.test.jsx
+++ b/src/components/common/base/Grid/Column/__tests__/Column.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mock from 'tests/mock';
+import Column from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
+
+describe('<Column />', () => {
+  // Arrange
+  const component = <Column>{seed.props.children}</Column>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/common/base/Grid/Column/__tests__/__snapshots__/Column.test.jsx.snap
+++ b/src/components/common/base/Grid/Column/__tests__/__snapshots__/Column.test.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Column /> Snapshot tests should render correctly 1`] = `
+<div
+  className="col"
+>
+  <div>
+    Content
+  </div>
+</div>
+`;

--- a/src/components/common/base/Grid/Column/index.jsx
+++ b/src/components/common/base/Grid/Column/index.jsx
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import exact from 'prop-types-exact';
+import React from 'react';
+
+const propTypes = exact({
+  children: PropTypes.node.isRequired,
+  size: PropTypes.string
+});
+
+const defaultProps = {
+  size: 'col'
+};
+
+function Column({ children, size }) {
+  return <div className={size}>{children}</div>;
+}
+
+Column.propTypes = propTypes;
+Column.defaultProps = defaultProps;
+
+export default Column;

--- a/src/components/common/base/Grid/Container/Container.stories.jsx
+++ b/src/components/common/base/Grid/Container/Container.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
+import Container from './index';
+
+const { content } = mock.elements;
+const title = 'Components/Common/Base/Grid/Container';
+const component = <Container>{content}</Container>;
+
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.minimal
+});

--- a/src/components/common/base/Grid/Container/__tests__/Container.test.jsx
+++ b/src/components/common/base/Grid/Container/__tests__/Container.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mock from 'tests/mock';
+import Container from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
+
+describe('<Container />', () => {
+  // Arrange
+  const component = <Container>{seed.props.children}</Container>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/common/base/Grid/Container/__tests__/__snapshots__/Container.test.jsx.snap
+++ b/src/components/common/base/Grid/Container/__tests__/__snapshots__/Container.test.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Container /> Snapshot tests should render correctly 1`] = `
+<div
+  className="container"
+>
+  <div>
+    Content
+  </div>
+</div>
+`;

--- a/src/components/common/base/Grid/Container/index.jsx
+++ b/src/components/common/base/Grid/Container/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Container({ children }) {
+  return <div className="container">{children}</div>;
+}
+
+export default Container;

--- a/src/components/common/base/Grid/Row/Row.stories.jsx
+++ b/src/components/common/base/Grid/Row/Row.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
+import Row from './index';
+
+const { content } = mock.elements;
+const title = 'Components/Common/Base/Grid/Row';
+const component = <Row>{content}</Row>;
+
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.minimal
+});

--- a/src/components/common/base/Grid/Row/__tests__/Row.test.jsx
+++ b/src/components/common/base/Grid/Row/__tests__/Row.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mock from 'tests/mock';
+import Row from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
+
+describe('<Row />', () => {
+  // Arrange
+  const component = <Row>{seed.props.children}</Row>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/common/base/Grid/Row/__tests__/__snapshots__/Row.test.jsx.snap
+++ b/src/components/common/base/Grid/Row/__tests__/__snapshots__/Row.test.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Row /> Snapshot tests should render correctly 1`] = `
+<div
+  className="row"
+>
+  <div>
+    Content
+  </div>
+</div>
+`;

--- a/src/components/common/base/Grid/Row/index.jsx
+++ b/src/components/common/base/Grid/Row/index.jsx
@@ -1,0 +1,22 @@
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import exact from 'prop-types-exact';
+import React from 'react';
+
+const propTypes = exact({
+  alignment: PropTypes.string,
+  children: PropTypes.node.isRequired
+});
+
+const defaultProps = {
+  alignment: ''
+};
+
+function Row({ alignment, children }) {
+  return <div className={cx('row', !!alignment && alignment)}>{children}</div>;
+}
+
+Row.propTypes = propTypes;
+Row.defaultProps = defaultProps;
+
+export default Row;

--- a/src/components/common/base/Grid/index.js
+++ b/src/components/common/base/Grid/index.js
@@ -1,4 +1,5 @@
+import Column from './Column';
 import Container from './Container';
 import Row from './Row';
 
-export default { Container, Row };
+export default { Column, Container, Row };

--- a/src/components/common/base/Grid/index.js
+++ b/src/components/common/base/Grid/index.js
@@ -1,3 +1,4 @@
 import Container from './Container';
+import Row from './Row';
 
-export default { Container };
+export default { Container, Row };

--- a/src/components/common/base/Grid/index.js
+++ b/src/components/common/base/Grid/index.js
@@ -1,0 +1,3 @@
+import Container from './Container';
+
+export default { Container };

--- a/src/components/common/base/Page/Body/Body.stories.jsx
+++ b/src/components/common/base/Page/Body/Body.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
+import Body from './index';
+
+const { content } = mock.elements;
+const title = 'Components/Common/Base/Page/Body';
+const component = <Body>{content}</Body>;
+
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.minimal
+});

--- a/src/components/common/base/Page/Body/__tests__/Body.test.jsx
+++ b/src/components/common/base/Page/Body/__tests__/Body.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mock from 'tests/mock';
+import Body from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
+
+describe('<Body />', () => {
+  // Arrange
+  const component = <Body>{seed.props.children}</Body>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/common/base/Page/Body/__tests__/__snapshots__/Body.test.jsx.snap
+++ b/src/components/common/base/Page/Body/__tests__/__snapshots__/Body.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Body /> Snapshot tests should render correctly 1`] = `
+<div>
+  Content
+</div>
+`;

--- a/src/components/common/base/Page/Body/index.jsx
+++ b/src/components/common/base/Page/Body/index.jsx
@@ -1,0 +1,5 @@
+function Body({ children }) {
+  return children;
+}
+
+export default Body;

--- a/src/components/common/base/Page/Document/Document.stories.jsx
+++ b/src/components/common/base/Page/Document/Document.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
+import Document from './index';
+
+const { content } = mock.elements;
+const title = 'Components/Common/Base/Page/Document';
+const component = <Document>{content}</Document>;
+
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.minimal
+});

--- a/src/components/common/base/Page/Document/__tests__/Document.test.jsx
+++ b/src/components/common/base/Page/Document/__tests__/Document.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mock from 'tests/mock';
+import Document from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
+
+describe('<Document />', () => {
+  // Arrange
+  const component = <Document>{seed.props.children}</Document>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/common/base/Page/Document/__tests__/__snapshots__/Document.test.jsx.snap
+++ b/src/components/common/base/Page/Document/__tests__/__snapshots__/Document.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Document /> Snapshot tests should render correctly 1`] = `
+<div>
+  Content
+</div>
+`;

--- a/src/components/common/base/Page/Document/index.jsx
+++ b/src/components/common/base/Page/Document/index.jsx
@@ -1,0 +1,5 @@
+function Document({ children }) {
+  return children;
+}
+
+export default Document;

--- a/src/components/common/base/Page/Head/Head.stories.jsx
+++ b/src/components/common/base/Page/Head/Head.stories.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Head from './index';
+
+const title = 'Components/Common/Base/Page/Head';
+const component = (
+  <Head>
+    <title>Document Title</title>
+    <meta name="description" content="Define a description of a web page" />
+  </Head>
+);
+
+storiesOf(title, module).add('default', () => component, {
+  notes: {
+    markdown: `**No view layer** - This component will manage all of changes to the document head. It takes plain HTML tags and outputs plain HTML tags. For more information, see [rect-helmet](https://github.com/nfl/react-helmet).
+    `
+  }
+});

--- a/src/components/common/base/Page/Head/__tests__/Head.test.jsx
+++ b/src/components/common/base/Page/Head/__tests__/Head.test.jsx
@@ -1,0 +1,36 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Head from '../index';
+
+const seed = {
+  props: {
+    children: <title>Page Title</title>
+  }
+};
+
+describe('<Head />', () => {
+  // Arrange
+  const component = <Head>{seed.props.children}</Head>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/common/base/Page/Head/__tests__/__snapshots__/Head.test.jsx.snap
+++ b/src/components/common/base/Page/Head/__tests__/__snapshots__/Head.test.jsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Head /> Snapshot tests should render correctly 1`] = `null`;

--- a/src/components/common/base/Page/Head/index.jsx
+++ b/src/components/common/base/Page/Head/index.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
+function Head({ children }) {
+  return <Helmet>{children}</Helmet>;
+}
+
+export default Head;

--- a/src/components/common/base/Page/index.js
+++ b/src/components/common/base/Page/index.js
@@ -1,0 +1,1 @@
+export { default as Document } from './Document';

--- a/src/components/common/base/Page/index.js
+++ b/src/components/common/base/Page/index.js
@@ -1,1 +1,2 @@
+export { default as Body } from './Body';
 export { default as Document } from './Document';

--- a/src/components/common/base/Page/index.js
+++ b/src/components/common/base/Page/index.js
@@ -1,2 +1,3 @@
 export { default as Body } from './Body';
 export { default as Document } from './Document';
+export { default as Head } from './Head';

--- a/src/components/common/composite/Layout/Layout.stories.jsx
+++ b/src/components/common/composite/Layout/Layout.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
+import Layout from './index';
+
+const { content } = mock.elements;
+const title = 'Components/Common/Composite/Layout';
+const component = <Layout>{content}</Layout>;
+
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.minimal
+});

--- a/src/components/common/composite/Layout/__tests__/Layout.test.jsx
+++ b/src/components/common/composite/Layout/__tests__/Layout.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mock from 'tests/mock';
+import Layout from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
+
+describe('<Layout />', () => {
+  // Arrange
+  const component = <Layout>{seed.props.children}</Layout>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/common/composite/Layout/__tests__/__snapshots__/Layout.test.jsx.snap
+++ b/src/components/common/composite/Layout/__tests__/__snapshots__/Layout.test.jsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Layout /> Snapshot tests should render correctly 1`] = `
+<div
+  className="row justify-content-sm-center"
+>
+  <div
+    className="col"
+  >
+    <div>
+      Content
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/common/composite/Layout/index.jsx
+++ b/src/components/common/composite/Layout/index.jsx
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+import exact from 'prop-types-exact';
+import React from 'react';
+
+import Grid from 'components/common/base/Grid';
+
+const propTypes = exact({
+  children: PropTypes.node.isRequired,
+  alignment: PropTypes.string,
+  size: PropTypes.string
+});
+
+const defaultProps = {
+  alignment: 'justify-content-sm-center',
+  size: 'col'
+};
+
+function Layout({ alignment, children, size }) {
+  return (
+    <Grid.Row alignment={alignment}>
+      <Grid.Column size={size}>{children}</Grid.Column>
+    </Grid.Row>
+  );
+}
+
+Layout.propTypes = propTypes;
+Layout.defaultProps = defaultProps;
+
+export default Layout;

--- a/src/components/core/document/Body/Body.stories.jsx
+++ b/src/components/core/document/Body/Body.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
+import Body from './index';
+
+const { content } = mock.elements;
+const title = 'Components/Core/Document/Body';
+const component = <Body>{content}</Body>;
+
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.minimal
+});

--- a/src/components/core/document/Body/__tests__/Body.test.jsx
+++ b/src/components/core/document/Body/__tests__/Body.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mock from 'tests/mock';
+import Body from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
+
+describe('<Body />', () => {
+  // Arrange
+  const component = <Body>{seed.props.children}</Body>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/core/document/Body/__tests__/__snapshots__/Body.test.jsx.snap
+++ b/src/components/core/document/Body/__tests__/__snapshots__/Body.test.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Body /> Snapshot tests should render correctly 1`] = `
+<div
+  className="sc-bdVaJa odROB"
+>
+  <div>
+    Content
+  </div>
+</div>
+`;

--- a/src/components/core/document/Body/index.jsx
+++ b/src/components/core/document/Body/index.jsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import exact from 'prop-types-exact';
+import React from 'react';
+import styled from 'styled-components';
+
+import HTML from 'constants/elements/html';
+
+const Frame = styled.div.attrs({ id: HTML.body })`
+  flex-basis: auto;
+  flex-grow: 1;
+  flex-shrink: 0;
+`;
+
+const propTypes = exact({
+  children: PropTypes.element.isRequired
+});
+
+function Body({ children }) {
+  return <Frame>{children}</Frame>;
+}
+
+Body.propTypes = propTypes;
+
+export default Body;

--- a/src/components/core/document/Footer/Footer.stories.jsx
+++ b/src/components/core/document/Footer/Footer.stories.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Footer from './index';
+
+const title = 'Components/Core/Document/Footer';
+const component = <Footer />;
+
+storiesOf(title, module).add('default', () => component);

--- a/src/components/core/document/Footer/__tests__/Footer.test.jsx
+++ b/src/components/core/document/Footer/__tests__/Footer.test.jsx
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Footer from '../index';
+
+describe('<Footer />', () => {
+  // Arrange
+  const component = <Footer />;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+});

--- a/src/components/core/document/Footer/index.jsx
+++ b/src/components/core/document/Footer/index.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Grid from 'components/common/base/Grid';
+
+const Frame = styled.footer`
+  background-color: #343a40;
+  color: #999;
+  flex-shrink: 0;
+  padding: 1.5rem 0;
+`;
+
+const Info = styled.div`
+  text-align: center;
+
+  @media (min-width: ${({ theme }) => theme.breakpoint.sm}) {
+    text-align: left;
+  }
+`;
+
+const Text = styled.p`
+  font-size: 0.75rem;
+  margin-bottom: 0.25rem;
+
+  :last-child {
+    margin-bottom: 0;
+  }
+`;
+
+function Footer() {
+  return (
+    <Frame>
+      <Grid.Container>
+        <Grid.Row>
+          <Grid.Column>
+            <Info>
+              <Text>Designed &amp; built with all the love in React.</Text>
+              <Text>Copyright © 2019 Theerawat Pongsupawat.</Text>
+            </Info>
+          </Grid.Column>
+        </Grid.Row>
+      </Grid.Container>
+    </Frame>
+  );
+}
+
+export default Footer;

--- a/src/components/core/document/Header/Header.stories.jsx
+++ b/src/components/core/document/Header/Header.stories.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Header from './index';
+
+const title = 'Components/Core/Document/Header';
+const component = <Header />;
+
+storiesOf(title, module).add('default', () => component);

--- a/src/components/core/document/Header/__tests__/Header.test.jsx
+++ b/src/components/core/document/Header/__tests__/Header.test.jsx
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Header from '../index';
+
+describe('<Header />', () => {
+  // Arrange
+  const component = <Header />;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+});

--- a/src/components/core/document/Header/index.jsx
+++ b/src/components/core/document/Header/index.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Grid from 'components/common/base/Grid';
+
+const Frame = styled.header`
+  background-color: #fff;
+  box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.2), 0 3px 3px -2px rgba(0, 0, 0, 0.14),
+    0 1px 8px 0 rgba(0, 0, 0, 0.12);
+  flex-shrink: 0;
+  left: 0;
+  padding: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 100%;
+  z-index: 1;
+`;
+
+const Content = styled.div`
+  align-items: center;
+  display: flex;
+  height: 30px;
+  justify-content: space-between;
+  margin: 0.5rem 0;
+`;
+
+function Header() {
+  return (
+    <Frame>
+      <Grid.Container>
+        <Grid.Row>
+          <Grid.Column>
+            <Content>Header</Content>
+          </Grid.Column>
+        </Grid.Row>
+      </Grid.Container>
+    </Frame>
+  );
+}
+
+export default Header;

--- a/src/components/core/index.js
+++ b/src/components/core/index.js
@@ -1,5 +1,6 @@
 // Document
 export { default as Body } from './document/Body';
+export { default as Header } from './document/Header';
 
 // Navigation
 export { default as Routes } from './navigation/Routes';

--- a/src/components/core/index.js
+++ b/src/components/core/index.js
@@ -3,3 +3,4 @@ export { default as Routes } from './navigation/Routes';
 
 // Skeleton
 export { default as Router } from './skeleton/Router';
+export { default as Theme } from './skeleton/Theme';

--- a/src/components/core/index.js
+++ b/src/components/core/index.js
@@ -4,3 +4,4 @@ export { default as Routes } from './navigation/Routes';
 // Skeleton
 export { default as Router } from './skeleton/Router';
 export { default as Theme } from './skeleton/Theme';
+export { default as Wrapper } from './skeleton/Wrapper';

--- a/src/components/core/index.js
+++ b/src/components/core/index.js
@@ -1,5 +1,6 @@
 // Document
 export { default as Body } from './document/Body';
+export { default as Footer } from './document/Footer';
 export { default as Header } from './document/Header';
 
 // Navigation

--- a/src/components/core/index.js
+++ b/src/components/core/index.js
@@ -1,3 +1,6 @@
+// Document
+export { default as Body } from './document/Body';
+
 // Navigation
 export { default as Routes } from './navigation/Routes';
 

--- a/src/components/core/index.js
+++ b/src/components/core/index.js
@@ -6,6 +6,9 @@ export { default as Header } from './document/Header';
 // Navigation
 export { default as Routes } from './navigation/Routes';
 
+// Sections
+export { default as Main } from './sections/Main';
+
 // Skeleton
 export { default as Router } from './skeleton/Router';
 export { default as Theme } from './skeleton/Theme';

--- a/src/components/core/navigation/Routes/Routes.stories.jsx
+++ b/src/components/core/navigation/Routes/Routes.stories.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import Router from 'stories/decorators/Router';
 import Routes from './index';
 
 const title = 'Components/Core/Navigation/Routes';
 const component = <Routes />;
 
-storiesOf(title, module)
-  .addDecorator(Router)
-  .add('default (404)', () => component);
+storiesOf(title, module).add('default (404)', () => component);

--- a/src/components/core/sections/Main/Main.stories.jsx
+++ b/src/components/core/sections/Main/Main.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
+import Main from './index';
+
+const { content } = mock.elements;
+const title = 'Components/Core/Sections/Main';
+const component = <Main>{content}</Main>;
+
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.minimal
+});

--- a/src/components/core/sections/Main/__tests__/Main.test.jsx
+++ b/src/components/core/sections/Main/__tests__/Main.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mock from 'tests/mock';
+import Main from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
+
+describe('<Main />', () => {
+  // Arrange
+  const component = <Main>{seed.props.children}</Main>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/core/sections/Main/__tests__/__snapshots__/Main.test.jsx.snap
+++ b/src/components/core/sections/Main/__tests__/__snapshots__/Main.test.jsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Main /> Snapshot tests should render correctly 1`] = `
+<main
+  className="sc-bdVaJa cIUQSX"
+>
+  <div
+    className="container"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <div>
+          Content
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+`;

--- a/src/components/core/sections/Main/index.jsx
+++ b/src/components/core/sections/Main/index.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import exact from 'prop-types-exact';
+import React from 'react';
+import styled from 'styled-components';
+
+import Grid from 'components/common/base/Grid';
+
+const Frame = styled.main`
+  margin-top: 2.875rem;
+`;
+
+const propTypes = exact({
+  children: PropTypes.element.isRequired
+});
+
+function Main({ children }) {
+  return (
+    <Frame>
+      <Grid.Container>
+        <Grid.Row>
+          <Grid.Column>{children}</Grid.Column>
+        </Grid.Row>
+      </Grid.Container>
+    </Frame>
+  );
+}
+
+Main.prototype = propTypes;
+
+export default Main;

--- a/src/components/core/skeleton/App/index.jsx
+++ b/src/components/core/skeleton/App/index.jsx
@@ -1,14 +1,36 @@
-import React from 'react';
+/* eslint-disable  */
+import * as React from 'react';
 import { hot } from 'react-hot-loader';
 
-import { Routes, Router } from 'components/core';
+import {
+  Body,
+  Footer,
+  Header,
+  Main,
+  Router,
+  Routes,
+  Theme,
+  Wrapper
+} from 'components/core';
 
-function App() {
-  return (
-    <Router>
-      <Routes />
-    </Router>
-  );
+class App extends React.Component {
+  render() {
+    return (
+      <Router>
+        <Theme>
+          <Wrapper>
+            <Header />
+            <Body>
+              <Main>
+                <Routes />
+              </Main>
+            </Body>
+            <Footer />
+          </Wrapper>
+        </Theme>
+      </Router>
+    );
+  }
 }
 
 export default hot(module)(App);

--- a/src/components/core/skeleton/Router/Router.stories.jsx
+++ b/src/components/core/skeleton/Router/Router.stories.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
 import Router from './index';
 
 const { content } = mock.elements;
 const title = 'Components/Core/Skeleton/Router';
 const component = <Router>{content}</Router>;
 
-storiesOf(title, module).add('default', () => component);
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.hoc
+});

--- a/src/components/core/skeleton/Router/__tests__/Router.test.jsx
+++ b/src/components/core/skeleton/Router/__tests__/Router.test.jsx
@@ -1,11 +1,18 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
+import mock from 'tests/mock';
 import Router from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
 
 describe('<Router />', () => {
   // Arrange
-  const component = <Router />;
+  const component = <Router>{seed.props.children}</Router>;
 
   describe('Unit tests', () => {
     it('should render without crashing', () => {

--- a/src/components/core/skeleton/Router/index.jsx
+++ b/src/components/core/skeleton/Router/index.jsx
@@ -1,7 +1,13 @@
+import PropTypes from 'prop-types';
+import exact from 'prop-types-exact';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { LastLocationProvider } from 'react-router-last-location';
 import ScrollMemory from 'react-router-scroll-memory';
+
+const propTypes = exact({
+  children: PropTypes.element.isRequired
+});
 
 function Router({ children }) {
   return (
@@ -13,5 +19,7 @@ function Router({ children }) {
     </BrowserRouter>
   );
 }
+
+Router.propTypes = propTypes;
 
 export default Router;

--- a/src/components/core/skeleton/Theme/Theme.stories.jsx
+++ b/src/components/core/skeleton/Theme/Theme.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
+import Theme from './index';
+
+const { content } = mock.elements;
+const title = 'Components/Core/Skeleton/Theme';
+const component = <Theme>{content}</Theme>;
+
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.hoc
+});

--- a/src/components/core/skeleton/Theme/__tests__/Theme.test.jsx
+++ b/src/components/core/skeleton/Theme/__tests__/Theme.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mock from 'tests/mock';
+import Theme from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
+
+describe('<Theme />', () => {
+  // Arrange
+  const component = <Theme>{seed.props.children}</Theme>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/core/skeleton/Theme/__tests__/__snapshots__/Theme.test.jsx.snap
+++ b/src/components/core/skeleton/Theme/__tests__/__snapshots__/Theme.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Theme /> Snapshot tests should render correctly 1`] = `
+<div>
+  Content
+</div>
+`;

--- a/src/components/core/skeleton/Theme/index.jsx
+++ b/src/components/core/skeleton/Theme/index.jsx
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+import exact from 'prop-types-exact';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import theme from 'config/theme';
+
+const propTypes = exact({
+  children: PropTypes.element.isRequired
+});
+
+function Theme({ children }) {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}
+
+Theme.propTypes = propTypes;
+
+export default Theme;

--- a/src/components/core/skeleton/Wrapper/Wrapper.stories.jsx
+++ b/src/components/core/skeleton/Wrapper/Wrapper.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import mock from 'stories/mock';
+import notes from 'stories/shared/notes';
+import Wrapper from './index';
+
+const { content } = mock.elements;
+const title = 'Components/Core/Skeleton/Wrapper';
+const component = <Wrapper>{content}</Wrapper>;
+
+storiesOf(title, module).add('default', () => component, {
+  notes: notes.minimal
+});

--- a/src/components/core/skeleton/Wrapper/__tests__/Wrapper.test.jsx
+++ b/src/components/core/skeleton/Wrapper/__tests__/Wrapper.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mock from 'tests/mock';
+import Wrapper from '../index';
+
+const seed = {
+  props: {
+    children: mock.elements.children
+  }
+};
+
+describe('<Wrapper />', () => {
+  // Arrange
+  const component = <Wrapper>{seed.props.children}</Wrapper>;
+
+  describe('Unit tests', () => {
+    it('should render without crashing', () => {
+      // Act
+      const wrapper = shallow(component);
+
+      // Assert
+      expect(wrapper).toBeDefined();
+    });
+  });
+
+  describe('Snapshot tests', () => {
+    it('should render correctly', () => {
+      // Act
+      const tree = renderer.create(component).toJSON();
+
+      // Assert
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/core/skeleton/Wrapper/__tests__/__snapshots__/Wrapper.test.jsx.snap
+++ b/src/components/core/skeleton/Wrapper/__tests__/__snapshots__/Wrapper.test.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Wrapper /> Snapshot tests should render correctly 1`] = `
+<div
+  className="sc-bdVaJa jaytjN"
+>
+  <div>
+    Content
+  </div>
+</div>
+`;

--- a/src/components/core/skeleton/Wrapper/index.jsx
+++ b/src/components/core/skeleton/Wrapper/index.jsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import exact from 'prop-types-exact';
+import React from 'react';
+import styled from 'styled-components';
+
+import HTML from 'constants/elements/html';
+
+const Frame = styled.div.attrs({ id: HTML.wrapper })`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
+
+const propTypes = exact({
+  children: PropTypes.node.isRequired
+});
+
+function Wrapper({ children }) {
+  return <Frame>{children}</Frame>;
+}
+
+Wrapper.propTypes = propTypes;
+
+export default Wrapper;

--- a/src/config/theme.js
+++ b/src/config/theme.js
@@ -1,0 +1,43 @@
+export default {
+  border: {
+    radius: 'calc(0.25rem - 1px)'
+  },
+  breakpoint: {
+    lg: '992px',
+    md: '768px',
+    sm: '576px',
+    xl: '1200px',
+    xs: '480px'
+  },
+  color: {
+    base: '#212529',
+    blue: '#007bff',
+    danger: '#dc3545',
+    dark: '#343a40',
+    cyan: '#17a2b8',
+    gray: '#6c757d',
+    green: '#28a745',
+    indigo: '#6610f2',
+    info: '#17a2b8',
+    light: '#f8f9fa',
+    mac: '#006fff',
+    orange: '#fd7e14',
+    pink: '#e83e8c',
+    primary: '#007bff',
+    purple: '#6f42c1',
+    red: '#dc3545',
+    secondary: '#6c757d',
+    success: '#28a745',
+    teal: '#20c997',
+    yellow: '#ffc107',
+    warning: '#ffc107',
+    white: '#ffffff'
+  },
+  font: {
+    weight: {
+      bold: 700,
+      light: 300,
+      normal: 400
+    }
+  }
+};

--- a/src/screens/main/Home/index.jsx
+++ b/src/screens/main/Home/index.jsx
@@ -1,21 +1,34 @@
 import React from 'react';
 
+import { Body, Document, Head } from 'components/common/base/Page';
+import Layout from 'components/common/composite/Layout';
+
 function Home() {
   return (
-    <div>
-      <h2>Home screen</h2>
-      <p>
-        Lorem Ipsum is simply dummy text of the printing and typesetting
-        industry. Lorem Ipsum has been the industry’s standard dummy text ever
-        since the 1500s, when an unknown printer took a galley of type and
-        scrambled it to make a type specimen book. It has survived not only five
-        centuries, but also the leap into electronic typesetting, remaining
-        essentially unchanged. It was popularised in the 1960s with the release
-        of Letraset sheets containing Lorem Ipsum passages, and more recently
-        with desktop publishing software like Aldus PageMaker including versions
-        of Lorem Ipsum.
-      </p>
-    </div>
+    <Document>
+      <Head>
+        <title>ギャラリー</title>
+        <meta
+          name="description"
+          content="A simple React app for collecting photos"
+        />
+      </Head>
+      <Body>
+        <Layout>
+          <p>
+            Lorem Ipsum is simply dummy text of the printing and typesetting
+            industry. Lorem Ipsum has been the industry’s standard dummy text
+            ever since the 1500s, when an unknown printer took a galley of type
+            and scrambled it to make a type specimen book. It has survived not
+            only five centuries, but also the leap into electronic typesetting,
+            remaining essentially unchanged. It was popularised in the 1960s
+            with the release of Letraset sheets containing Lorem Ipsum passages,
+            and more recently with desktop publishing software like Aldus
+            PageMaker including versions of Lorem Ipsum.
+          </p>
+        </Layout>
+      </Body>
+    </Document>
   );
 }
 

--- a/src/screens/main/NotFound/index.jsx
+++ b/src/screens/main/NotFound/index.jsx
@@ -1,21 +1,24 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { Body, Document, Head } from 'components/common/base/Page';
+import Layout from 'components/common/composite/Layout';
+import PATHS from 'constants/routes/paths';
 
 function NotFound() {
   return (
-    <div>
-      <h2>NotFound screen</h2>
-      <p>
-        Lorem Ipsum is simply dummy text of the printing and typesetting
-        industry. Lorem Ipsum has been the industry’s standard dummy text ever
-        since the 1500s, when an unknown printer took a galley of type and
-        scrambled it to make a type specimen book. It has survived not only five
-        centuries, but also the leap into electronic typesetting, remaining
-        essentially unchanged. It was popularised in the 1960s with the release
-        of Letraset sheets containing Lorem Ipsum passages, and more recently
-        with desktop publishing software like Aldus PageMaker including versions
-        of Lorem Ipsum.
-      </p>
-    </div>
+    <Document>
+      <Head>
+        <title>Page not found · ギャラリー</title>
+      </Head>
+      <Body>
+        <Layout>
+          <h2>404</h2>
+          <p>This is not webpage you are looking for.</p>
+          <Link to={PATHS.root}>Go back to Home page</Link>
+        </Layout>
+      </Body>
+    </Document>
   );
 }
 

--- a/src/stories/decorators/Router.jsx
+++ b/src/stories/decorators/Router.jsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
-
-function Router(story) {
-  return <BrowserRouter>{story()}</BrowserRouter>;
-}
-
-export default Router;

--- a/src/stories/shared/notes.js
+++ b/src/stories/shared/notes.js
@@ -1,4 +1,5 @@
 export default {
+  hoc: 'An HOC returning children getting passed into a component.',
   minimal:
     'A minimal UI component returning children wrapping inside a container.',
   skeleton: 'A skeleton component, no view layer.'

--- a/src/styles/base/_custom.scss
+++ b/src/styles/base/_custom.scss
@@ -1,0 +1,2 @@
+// Typography
+$font-size-base: 0.875rem;

--- a/src/styles/base/_normalize.scss
+++ b/src/styles/base/_normalize.scss
@@ -1,0 +1,5 @@
+// Prevent elements flicker after being touched on touch devices
+html,
+body {
+  -webkit-tap-highlight-color: transparent;
+}

--- a/src/styles/base/_settings.scss
+++ b/src/styles/base/_settings.scss
@@ -1,0 +1,12 @@
+// Breakpoints
+$breakpoint-sm: 576px;
+$breakpoint-md: 768px;
+$breakpoint-lg: 992px;
+$breakpoint-xl: 1200px;
+
+// Screen sizes
+$screen-xs: 320px;
+$screen-sm: 576px;
+$screen-md: 768px;
+$screen-lg: 992px;
+$screen-xl: 1200px;

--- a/src/styles/skeleton/_layout.scss
+++ b/src/styles/skeleton/_layout.scss
@@ -1,0 +1,9 @@
+html,
+body,
+.root {
+  height: 100%;
+}
+
+body {
+  min-width: $screen-xs;
+}


### PR DESCRIPTION
- Add Jest snapshot (JSX) to VSCode's file association list
- Override extended Stylelint shareable rules (Styled Components)
- Add Styled Components’s theme variables with essential values
- Update shared Storybook notes
- Add Router decorator to Storybook configuration
- Add Styled Components’s theme decorator to Storybook configuration
- Remove unnecessary Storybook Router decorator
- Add base styles for scaffolding app layout & visuals
- Create page layout/structure components
- Refactor app structure
- Refactor Home & NotFound screens with page layout structure
- Refactor Router & Routes components